### PR TITLE
(GH-78) Add GH Actions build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
-name: GitHub Pages
+name: Build Site
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main # Set a branch to deploy
+  pull_request:
 
 jobs:
   deploy:
@@ -39,8 +36,3 @@ jobs:
       - run: npm ci
       - run: hugo mod get -u
       - run: hugo --minify
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Overview of PR:

- Added `build` workflow which will build from a pull request. 
- `gh-pages` workflow is now just for deploying when the workflow is run manually or
when the main branch is changed.